### PR TITLE
 BUG: Changed xrange() to range() for python 3.6 compatibility

### DIFF
--- a/ProstateMRIUSContourPropagation/ProstateMRIUSContourPropagation.py
+++ b/ProstateMRIUSContourPropagation/ProstateMRIUSContourPropagation.py
@@ -442,7 +442,7 @@ class ProstateMRIUSContourPropagationWidget(ScriptedLoadableModuleWidget):
 
     segmentIDs = vtk.vtkStringArray()
     segmentationNode.GetSegmentation().GetSegmentIDs(segmentIDs)
-    for segmentIndex in xrange(0,segmentIDs.GetNumberOfValues()):
+    for segmentIndex in range(0,segmentIDs.GetNumberOfValues()):
       segmentID = segmentIDs.GetValue(segmentIndex)
       segment = segmentationNode.GetSegmentation().GetSegment(segmentID)
       prostateSegmentNameCombobox.addItem(segment.GetName(),segmentID)
@@ -466,7 +466,7 @@ class ProstateMRIUSContourPropagationWidget(ScriptedLoadableModuleWidget):
     shNode = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)
     children = vtk.vtkIdList()
     shNode.GetItemChildren(shNode.GetSceneItemID(), children)
-    for i in xrange(children.GetNumberOfIds()):
+    for i in range(children.GetNumberOfIds()):
       child = children.GetId(i)
       if shNode.GetItemLevel(child) == slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMLevelPatient():
         # Try to guess patient selection by patient name
@@ -567,7 +567,7 @@ class ProstateMRIUSContourPropagationLogic(ScriptedLoadableModuleLogic):
     self.usSegmentationNode = None
     usSeriesCollection = vtk.vtkCollection()
     shNode.GetDataNodesInBranch(self.usPatientShItemID, usSeriesCollection)
-    for i in xrange(0,usSeriesCollection.GetNumberOfItems()):
+    for i in range(0,usSeriesCollection.GetNumberOfItems()):
       currentDataNode = usSeriesCollection.GetItemAsObject(i)
       if currentDataNode.IsA('vtkMRMLScalarVolumeNode') and not currentDataNode.IsA('vtkMRMLSegmentationNode'):
         currentSeriesItemID = shNode.GetItemByDataNode(currentDataNode)
@@ -590,7 +590,7 @@ class ProstateMRIUSContourPropagationLogic(ScriptedLoadableModuleLogic):
     self.mrSegmentationNode = None
     mrSeriesCollection = vtk.vtkCollection()
     shNode.GetDataNodesInBranch(self.mrPatientShItemID, mrSeriesCollection)
-    for i in xrange(0,mrSeriesCollection.GetNumberOfItems()):
+    for i in range(0,mrSeriesCollection.GetNumberOfItems()):
       currentDataNode = mrSeriesCollection.GetItemAsObject(i)
       if currentDataNode.IsA('vtkMRMLScalarVolumeNode') and not currentDataNode.IsA('vtkMRMLSegmentationNode'):
         currentSeriesItemID = shNode.GetItemByDataNode(currentDataNode)
@@ -1159,7 +1159,7 @@ class ProstateMRIUSContourPropagationLogic(ScriptedLoadableModuleLogic):
     header.InsertNextValue("2D I-S")
 
     # Calculate error metrics
-    for index in xrange(self.usFiducialsNode.GetNumberOfFiducials()):
+    for index in range(self.usFiducialsNode.GetNumberOfFiducials()):
       usPos = [0,0,0]
       self.usFiducialsNode.GetNthFiducialPosition(index,usPos)
       mrPos = [0,0,0]

--- a/ProstateMRIUSContourPropagation/ProstateMRIUSContourPropagation.py
+++ b/ProstateMRIUSContourPropagation/ProstateMRIUSContourPropagation.py
@@ -1206,7 +1206,7 @@ class ProstateMRIUSContourPropagationTest(ScriptedLoadableModuleTest):
       self.TestSection_03_CalculateSimilarity()
       self.TestUtility_ClearDatabase()
 
-    except Exception, e:
+    except Exception as e:
       logging.error('Exception happened! Details:')
       import traceback
       traceback.print_exc()
@@ -1256,7 +1256,7 @@ class ProstateMRIUSContourPropagationTest(ScriptedLoadableModuleTest):
       self.assertTrue( slicer.dicomDatabase.isOpen )
       slicer.dicomDatabase.initializeDatabase()
 
-    except Exception, e:
+    except Exception as e:
       import traceback
       traceback.print_exc()
       self.delayDisplay('Test caused exception!\n' + str(e),self.delayMs*2)
@@ -1291,7 +1291,7 @@ class ProstateMRIUSContourPropagationTest(ScriptedLoadableModuleTest):
       numOfFilesInDicomDataDirTest = len([file for folderList in [files for root, subdirs, files in os.walk(self.dicomDataDir)] for file in folderList])
       self.assertEqual( numOfFilesInDicomDataDirTest, self.expectedNumOfFilesInDicomDataDir )
 
-    except Exception, e:
+    except Exception as e:
       import traceback
       traceback.print_exc()
       self.delayDisplay('Test caused exception!\n' + str(e),self.delayMs*2)
@@ -1314,7 +1314,7 @@ class ProstateMRIUSContourPropagationTest(ScriptedLoadableModuleTest):
       self.assertEqual( len(slicer.dicomDatabase.patients()), 1 )
       self.assertIsNotNone( slicer.dicomDatabase.patients()[0] )
 
-    except Exception, e:
+    except Exception as e:
       import traceback
       traceback.print_exc()
       self.delayDisplay('Test caused exception!\n' + str(e),self.delayMs*2)
@@ -1360,7 +1360,7 @@ class ProstateMRIUSContourPropagationTest(ScriptedLoadableModuleTest):
       self.assertEqual( len( slicer.util.getNodes('vtkMRMLScalarVolumeNode*') ), numOfScalarVolumeNodesBeforeLoad + 2 )
       self.assertEqual( len( slicer.util.getNodes('vtkMRMLSegmentationNode*') ), numOfSegmentationNodesBeforeLoad + 2 )
 
-    except Exception, e:
+    except Exception as e:
       import traceback
       traceback.print_exc()
       self.delayDisplay('Test caused exception!\n' + str(e),self.delayMs*2)
@@ -1425,7 +1425,7 @@ class ProstateMRIUSContourPropagationTest(ScriptedLoadableModuleTest):
       self.assertIsNotNone(mrVolumeNode)
       self.assertIsNotNone(mrVolumeNode.GetParentTransformNode())
 
-    except Exception, e:
+    except Exception as e:
       import traceback
       traceback.print_exc()
       self.delayDisplay('Test caused exception!\n' + str(e),self.delayMs*2)
@@ -1468,7 +1468,7 @@ class ProstateMRIUSContourPropagationTest(ScriptedLoadableModuleTest):
       self.assertLess(hausdorffTable.GetValue(5,1).ToDouble(), 1)
       self.assertLess(hausdorffTable.GetValue(6,1).ToDouble(), 2.5)
 
-    except Exception, e:
+    except Exception as e:
       import traceback
       traceback.print_exc()
       self.delayDisplay('Test caused exception!\n' + str(e),self.delayMs*2)

--- a/SegmentRegistration/SegmentRegistration.py
+++ b/SegmentRegistration/SegmentRegistration.py
@@ -724,7 +724,7 @@ class SegmentRegistrationTest(ScriptedLoadableModuleTest):
       self.TestSection_01_LoadDicomData()
       self.TestSection_02_PerformRegistration()
 
-    except Exception, e:
+    except Exception as e:
       logging.error('Exception happened! Details:')
       import traceback
       traceback.print_exc()
@@ -773,7 +773,7 @@ class SegmentRegistrationTest(ScriptedLoadableModuleTest):
             {}, loadedNodes) as success:
           self.assertTrue(success)
 
-    except Exception, e:
+    except Exception as e:
       import traceback
       traceback.print_exc()
       self.delayDisplay('Test caused exception!\n' + str(e),self.delayMs*2)
@@ -839,7 +839,7 @@ class SegmentRegistrationTest(ScriptedLoadableModuleTest):
       self.assertIsNotNone(mrVolumeNode)
       self.assertIsNotNone(mrVolumeNode.GetParentTransformNode())
 
-    except Exception, e:
+    except Exception as e:
       import traceback
       traceback.print_exc()
       self.delayDisplay('Test caused exception!\n' + str(e),self.delayMs*2)

--- a/SegmentRegistration/SegmentRegistration.py
+++ b/SegmentRegistration/SegmentRegistration.py
@@ -318,7 +318,7 @@ class SegmentRegistrationWidget(ScriptedLoadableModuleWidget):
 
     segmentIDs = vtk.vtkStringArray()
     segmentationNode.GetSegmentation().GetSegmentIDs(segmentIDs)
-    for segmentIndex in xrange(0,segmentIDs.GetNumberOfValues()):
+    for segmentIndex in range(0,segmentIDs.GetNumberOfValues()):
       segmentID = segmentIDs.GetValue(segmentIndex)
       segment = segmentationNode.GetSegmentation().GetSegment(segmentID)
       segmentNameCombobox.addItem(segment.GetName(),segmentID)


### PR DESCRIPTION
One last compatibility issue. Things are working with Slicer 4.11.0-2019-05-24 version.