### PR TITLE
Fix crash due to missing cropped volume (switch to MarkupsROI)

### DIFF
--- a/SegmentRegistration/SegmentRegistration.py
+++ b/SegmentRegistration/SegmentRegistration.py
@@ -379,7 +379,7 @@ class SegmentRegistrationLogic(ScriptedLoadableModuleLogic):
       return
 
     # Create ROI
-    roiNode = slicer.vtkMRMLAnnotationROINode()
+    roiNode = slicer.vtkMRMLMarkupsROINode()
     roiNode.SetName('CropROI_' + self.movingVolumeNode.GetName())
     slicer.mrmlScene.AddNode(roiNode)
 


### PR DESCRIPTION
Without this change the module fails to run and this error is hidden in the logs:
```
Switch to module:  "SegmentRegistration"
CropVolume: Invalid input volume or ROI
```

This happens because AnnotationROIs are not longer supported in the Slicer core.

Tested in 5.6.2 and this should work in all later versions too.